### PR TITLE
Hook Black Serpent spawns into Nar Shaddaa

### DIFF
--- a/Module/itp/waypointpalcus.itp.json
+++ b/Module/itp/waypointpalcus.itp.json
@@ -450,6 +450,17 @@
                     "__struct_id": 0,
                     "NAME": {
                       "type": "cexostring",
+                      "value": "Nar Shaddaa Black Serpents"
+                    },
+                    "RESREF": {
+                      "type": "resref",
+                      "value": "nar_blackserpent"
+                    }
+                  },
+                  {
+                    "__struct_id": 0,
+                    "NAME": {
+                      "type": "cexostring",
                       "value": "Nar Shaddaa CMD Droid"
                     },
                     "RESREF": {

--- a/Module/utw/nar_blackserpent.utw.json
+++ b/Module/utw/nar_blackserpent.utw.json
@@ -1,0 +1,49 @@
+{
+  "__data_type": "UTW ",
+  "Appearance": {
+    "type": "byte",
+    "value": 2
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "HasMapNote": {
+    "type": "byte",
+    "value": 0
+  },
+  "LinkedTo": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Nar Shaddaa Black Serpents"
+    }
+  },
+  "MapNote": {
+    "type": "cexolocstring",
+    "value": {}
+  },
+  "MapNoteEnabled": {
+    "type": "byte",
+    "value": 0
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "NAR_BLACK_SERPENTS"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "nar_blackserpent"
+  }
+}


### PR DESCRIPTION
### Motivation
- The `NAR_BLACK_SERPENTS` spawn table was defined in code but had no placed spawn waypoints or builder palette entry, making the Black Serpent NPC template unreachable in module content.
- Add placed spawn points and a waypoint template so the Black Serpents can spawn in the Nar Shaddaa dungeon and be selectable in the module builder.

### Description
- Added a new waypoint template file `Module/utw/nar_blackserpent.utw.json` that registers `NAR_BLACK_SERPENTS` with the `nar_blackserpent` resref.
- Inserted five `NAR_BLACK_SERPENTS` waypoint instances into `Module/git/spacenarshaddung.git.json` near the existing Serpent Leader route so the spawn table is referenced by placed content.
- Updated the custom waypoint palette `Module/itp/waypointpalcus.itp.json` to include the `nar_blackserpent` entry for builder visibility and placement.

### Testing
- Ran `python3 -m json.tool` on `Module/git/spacenarshaddung.git.json`, `Module/itp/waypointpalcus.itp.json`, and `Module/utw/nar_blackserpent.utw.json` and the JSON files validated successfully.
- Searched for `NAR_BLACK_SERPENTS`/`nar_blackserpent` with `rg` across `Module/git`, `Module/utw`, `Module/itp`, and the spawn definition and confirmed the new references are present.
- Ran `git diff --check` to ensure no trailing whitespace or similar issues and it returned clean.
- Attempted `dotnet build SWLOR.Game.Server.sln --no-restore` but it was not run in this environment because `dotnet` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7936e2e88329940c92c67ec46bf4)