### PR TITLE
Make SpaceNarShaddaDungeon exterior so weather can trigger

### DIFF
--- a/Module/are/spacenarshaddung.are.json
+++ b/Module/are/spacenarshaddung.are.json
@@ -30,7 +30,7 @@
   },
   "Flags": {
     "type": "dword",
-    "value": 2
+    "value": 0
   },
   "FogClipDist": {
     "type": "float",


### PR DESCRIPTION
### Motivation
- SpaceNarShaddaDungeon was flagged as interior/underground which caused the weather service to early-return in `SetWeather`/`DoWeatherEffects`, preventing weather placeables and effects from being created or applied.

### Description
- Update `Module/are/spacenarshaddung.are.json` by changing the `Flags` value from `2` to `0` so the area is treated as a normal exterior/above-ground area and will be processed by the weather system.

### Testing
- Validated the JSON with `python -m json.tool`, ran a Python check that asserts the area `Tag` is `SpaceNarShaddaDungeon` and `Flags == 0`, and executed `git diff --check`; a .NET build was not run because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff79f60e508329a346aa50dfb8e858)