### PR TITLE
Fix Smuggler's Moon progression ids

### DIFF
--- a/Module/dlg/tatsmugglerquest.dlg.json
+++ b/Module/dlg/tatsmugglerquest.dlg.json
@@ -1077,7 +1077,7 @@
               },
               "Value": {
                 "type": "cexostring",
-                "value": " smuggler_favor"
+                "value": "smuggler_favor"
               }
             }
           ]

--- a/Module/git/narshadorbit.git.json
+++ b/Module/git/narshadorbit.git.json
@@ -9335,6 +9335,21 @@
           "type": "int",
           "value": 138
         }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "MAP_KEY_ITEM_ID"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 82
+        }
       }
     ]
   },

--- a/Module/git/pw_ar_narcatwalk.git.json
+++ b/Module/git/pw_ar_narcatwalk.git.json
@@ -112750,7 +112750,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 83
+          "value": 84
         }
       }
     ]

--- a/Module/git/pw_ar_nscasino.git.json
+++ b/Module/git/pw_ar_nscasino.git.json
@@ -97485,7 +97485,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 82
+          "value": 83
         }
       }
     ]

--- a/Module/git/spacenarshalower.git.json
+++ b/Module/git/spacenarshalower.git.json
@@ -16964,11 +16964,11 @@
         },
         "Type": {
           "type": "dword",
-          "value": 3
+          "value": 1
         },
         "Value": {
-          "type": "cexostring",
-          "value": "122"
+          "type": "int",
+          "value": 140
         }
       },
       {

--- a/SWLOR.Game.Server/Service/AchievementService/AchievementType.cs
+++ b/SWLOR.Game.Server/Service/AchievementService/AchievementType.cs
@@ -386,6 +386,9 @@ namespace SWLOR.Game.Server.Service.AchievementService
 
 		[Achievement("Explore Smuggler's Moon Station - Abandoned", "Explore Smuggler's Moon Station - Abandoned.", true)]
 		ExploreSmugglersMoonStationAbandoned = 139,
+
+		[Achievement("Explore Smuggler's Moon Station - Lower Level", "Explore Smuggler's Moon Station - Lower Level.", true)]
+		ExploreSmugglersMoonStationLowerLevel = 140,
 	}
 
     public class AchievementAttribute: Attribute


### PR DESCRIPTION
### Motivation
- Ensure the `smuggler_favor` dialog action passes the exact quest id so `Quest.AdvanceQuest` can find the quest entry. 
- Correct map key item locals so owning the correct map reveals the appropriate Smuggler's Moon areas (Casino, Catwalks, Orbit). 
- Store and expose the Smuggler's Moon Station lower-level exploration achievement as an integer and add the corresponding achievement enum so area progression/achievements function correctly.

### Description
- Removed a leading space from the dialog action argument in `Module/dlg/tatsmugglerquest.dlg.json` so the value is `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff840597cc83299109ff7e46776932)