### PR TITLE
Fix Smuggler's Moon map key, add Sludge Eel UTI, and add planet descriptions

### DIFF
--- a/Module/uti/map_82.uti.json
+++ b/Module/uti/map_82.uti.json
@@ -123,7 +123,7 @@
         },
         "Value": {
           "type": "int",
-          "value": 83
+          "value": 82
         }
       }
     ]

--- a/Module/uti/ns_sludge_eel.uti.json
+++ b/Module/uti/ns_sludge_eel.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 0
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 526
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 0
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A slick, neon-tainted eel harvested from Nar Shaddaa's polluted undercity channels. Used in local street cuisine and specialty recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": ""
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Sludge Eel"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 17
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "ns_sludge_eel"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "ns_sludge_eel"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 17
+  }
+}

--- a/SWLOR.Game.Server/Enumeration/PlanetType.cs
+++ b/SWLOR.Game.Server/Enumeration/PlanetType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SWLOR.Game.Server.Enumeration
 {
@@ -77,18 +78,20 @@ namespace SWLOR.Game.Server.Enumeration
 			1000,
 			true)]
 		Dantooine = 128,
+		[Description("Smuggler's Moon")]
 		[Planet("Smuggler's Moon",
 			"Smuggler's Moon - ",
 			"SmugglersMoon_Orbit",
 			"SMUGGLERS_MOON_LANDING",
-					0,
+			0,
 			true)]
 		SmugglersMoon = 256,
+		[Description("Smuggler's Moon Station")]
 		[Planet("Smuggler's Moon Station",
 			"Smuggler's Moon Station - ",
 			"Smugglers_Station_Orbit",
 			"SMUGGLERS_STATION_LANDING",
-					0,
+			0,
 			true)]
 		SmugglersMoonStation = 512,
 	}


### PR DESCRIPTION
### Motivation
- Prevent the Smuggler's Moon Orbit Map from granting the wrong key item and avoid collisions with the casino map key item.
- Ensure the new Boga Noga cooking recipe and Nar Shaddaa loot can actually produce/contain the `ns_sludge_eel` component.
- Make weather/service lookups match area name prefixes for the newly added Smuggler's Moon areas so climate selection works correctly.

### Description
- Corrected the map key on the Orbit map by changing the `KEY_ITEM_ID` in `Module/uti/map_82.uti.json` from `83` to `82` so it grants the orbit map key item.
- Added a new UTI resource `Module/uti/ns_sludge_eel.uti.json` with `Tag`/`TemplateResRef` set to `ns_sludge_eel` so the loot table and recipes can reference it.
- Added `using System.ComponentModel;` and `Description` attributes to the `Smuggler's Moon` and `Smuggler's Moon Station` entries in `SWLOR.Game.Server/Enumeration/PlanetType.cs` so `GetDescriptionAttribute()` returns the planet names that match area prefixes for weather lookup.

### Testing
- Ran JSON validation with `python -m json.tool Module/uti/map_82.uti.json` and `python -m json.tool Module/uti/ns_sludge_eel.uti.json`, which succeeded.
- Attempted to run `dotnet build SWLOR.Game.Server.sln --no-restore` but it could not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff991bf1748329ba91c18468e55eb7)