### PR TITLE
Add Arkania planet, thermal generator system, quests, dialog, and weather integration

### DIFF
--- a/SWLOR.Game.Server/Entity/ArkaniaGeneratorState.cs
+++ b/SWLOR.Game.Server/Entity/ArkaniaGeneratorState.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace SWLOR.Game.Server.Entity
+{
+    public class ArkaniaGeneratorState : EntityBase
+    {
+        public ArkaniaGeneratorState()
+        {
+            Id = "ARKANIA_GENERATOR";
+            HeatReserve = 50;
+            Integrity = 100;
+            Morale = 50;
+            LastUpdated = DateTime.UtcNow;
+        }
+
+        public int HeatReserve { get; set; }
+        public int Integrity { get; set; }
+        public int Coal { get; set; }
+        public int MachineParts { get; set; }
+        public int HeatCores { get; set; }
+        public int MedicalSupplies { get; set; }
+        public int ForecastData { get; set; }
+        public int Morale { get; set; }
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/SWLOR.Game.Server/Enumeration/PlanetType.cs
+++ b/SWLOR.Game.Server/Enumeration/PlanetType.cs
@@ -76,7 +76,15 @@ namespace SWLOR.Game.Server.Enumeration
             "DANTOOINE_LANDING",
             1000,
             true)]
-            Dantooine = 128,
+        Dantooine = 128,
+        // Keep inactive until the module has Arkania landing/orbit waypoints and travel content.
+        [Planet("Arkania",
+            "Arkania - ",
+            "Arkania_Orbit",
+            "ARKANIA_LANDING",
+            600,
+            false)]
+        Arkania = 256,
     }
 
     public class PlanetAttribute : Attribute

--- a/SWLOR.Game.Server/Feature/DialogDefinition/ArkaniaGeneratorDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/ArkaniaGeneratorDialog.cs
@@ -1,0 +1,156 @@
+﻿using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.DialogService;
+
+namespace SWLOR.Game.Server.Feature.DialogDefinition
+{
+    public class ArkaniaGeneratorDialog : DialogBase
+    {
+        private const string MainPageId = "MAIN_PAGE";
+        private const string FuelPageId = "FUEL_PAGE";
+        private const string RepairPageId = "REPAIR_PAGE";
+        private const string SupportPageId = "SUPPORT_PAGE";
+
+        public override PlayerDialog SetUp(uint player)
+        {
+            var builder = new DialogBuilder()
+                .AddPage(MainPageId, MainPageInit)
+                .AddPage(FuelPageId, FuelPageInit)
+                .AddPage(RepairPageId, RepairPageInit)
+                .AddPage(SupportPageId, SupportPageInit);
+
+            return builder.Build();
+        }
+
+        private void MainPageInit(DialogPage page)
+        {
+            page.Header = ColorToken.Green("Arkanian Thermal Generator\n\n") +
+                          "The generator shudders beneath layers of frost-covered plating. " +
+                          "Every gauge is another reminder that the city survives only while the heat holds.\n\n" +
+                          ArkaniaGenerator.BuildStatusText();
+
+            page.AddResponse("Contribute fuel", () => ChangePage(FuelPageId));
+            page.AddResponse("Contribute repair parts", () => ChangePage(RepairPageId));
+            page.AddResponse("Support the wards or forecast team", () => ChangePage(SupportPageId));
+        }
+
+        private void FuelPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            page.Header = ColorToken.Green("Fuel Intake\n\n") +
+                          "Coal keeps the exchangers alive. Heat cores are reserved for emergencies.\n\n" +
+                          GetInventorySummary(player);
+
+            page.AddResponse("Deposit one coal crate", () => Deposit(player, ArkaniaGenerator.CoalResref, 1, "coal crate"));
+            page.AddResponse("Deposit five coal crates", () => Deposit(player, ArkaniaGenerator.CoalResref, 5, "coal crates"));
+            page.AddResponse("Deposit one heat core", () => Deposit(player, ArkaniaGenerator.HeatCoreResref, 1, "heat core"));
+            page.AddResponse("Return to generator status", () => ChangePage(MainPageId));
+        }
+
+        private void RepairPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            page.Header = ColorToken.Green("Maintenance Intake\n\n") +
+                          "The generator can burn fuel only as long as its regulators and conduits hold.\n\n" +
+                          GetInventorySummary(player);
+
+            page.AddResponse("Deposit one machine part", () => Deposit(player, ArkaniaGenerator.MachinePartResref, 1, "machine part"));
+            page.AddResponse("Deposit five machine parts", () => Deposit(player, ArkaniaGenerator.MachinePartResref, 5, "machine parts"));
+            page.AddResponse("Return to generator status", () => ChangePage(MainPageId));
+        }
+
+        private void SupportPageInit(DialogPage page)
+        {
+            var player = GetPC();
+            page.Header = ColorToken.Green("Civil Support\n\n") +
+                          "The generator keeps bodies warm. The wards and forecast station keep hope alive.\n\n" +
+                          GetInventorySummary(player);
+
+            page.AddResponse("Deposit one medical supply pack", () => Deposit(player, ArkaniaGenerator.MedicalSuppliesResref, 1, "medical supply pack"));
+            page.AddResponse("Deposit one forecast data spool", () => Deposit(player, ArkaniaGenerator.ForecastDataResref, 1, "forecast data spool"));
+            page.AddResponse("Return to generator status", () => ChangePage(MainPageId));
+        }
+
+        private string GetInventorySummary(uint player)
+        {
+            return
+                $"You are carrying:\n" +
+                $"Coal: {CountItems(player, ArkaniaGenerator.CoalResref)}\n" +
+                $"Machine Parts: {CountItems(player, ArkaniaGenerator.MachinePartResref)}\n" +
+                $"Heat Cores: {CountItems(player, ArkaniaGenerator.HeatCoreResref)}\n" +
+                $"Medical Supplies: {CountItems(player, ArkaniaGenerator.MedicalSuppliesResref)}\n" +
+                $"Forecast Data: {CountItems(player, ArkaniaGenerator.ForecastDataResref)}";
+        }
+
+        private void Deposit(uint player, string resref, int amount, string displayName)
+        {
+            if (!RemoveItems(player, resref, amount))
+            {
+                FloatingTextStringOnCreature($"You do not have enough {displayName}.", player, false);
+                return;
+            }
+
+            if (resref == ArkaniaGenerator.CoalResref)
+            {
+                ArkaniaGenerator.AddCoal(amount);
+            }
+            else if (resref == ArkaniaGenerator.HeatCoreResref)
+            {
+                ArkaniaGenerator.AddHeatCores(amount);
+            }
+            else if (resref == ArkaniaGenerator.MachinePartResref)
+            {
+                ArkaniaGenerator.AddMachineParts(amount);
+            }
+            else if (resref == ArkaniaGenerator.MedicalSuppliesResref)
+            {
+                ArkaniaGenerator.AddMedicalSupplies(amount);
+            }
+            else if (resref == ArkaniaGenerator.ForecastDataResref)
+            {
+                ArkaniaGenerator.AddForecastData(amount);
+            }
+
+            FloatingTextStringOnCreature($"The city receives {amount} {displayName}.", player, false);
+            ChangePage(MainPageId, false);
+        }
+
+        private int CountItems(uint player, string resref)
+        {
+            var count = 0;
+            for (var item = GetFirstItemInInventory(player); GetIsObjectValid(item); item = GetNextItemInInventory(player))
+            {
+                if (GetResRef(item) == resref)
+                {
+                    count += GetItemStackSize(item);
+                }
+            }
+
+            return count;
+        }
+
+        private bool RemoveItems(uint player, string resref, int amount)
+        {
+            if (CountItems(player, resref) < amount)
+                return false;
+
+            var remaining = amount;
+            var item = GetFirstItemInInventory(player);
+            while (GetIsObjectValid(item) && remaining > 0)
+            {
+                var nextItem = GetNextItemInInventory(player);
+
+                if (GetResRef(item) == resref)
+                {
+                    var stackSize = GetItemStackSize(item);
+                    var reduceBy = stackSize > remaining ? remaining : stackSize;
+                    Item.ReduceItemStack(item, reduceBy);
+                    remaining -= reduceBy;
+                }
+
+                item = nextItem;
+            }
+
+            return true;
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/QuestDefinition/ArkaniaQuestDefinition.cs
+++ b/SWLOR.Game.Server/Feature/QuestDefinition/ArkaniaQuestDefinition.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using SWLOR.Game.Server.Service;
+using SWLOR.Game.Server.Service.QuestService;
+
+namespace SWLOR.Game.Server.Feature.QuestDefinition
+{
+    public class ArkaniaQuestDefinition : IQuestListDefinition
+    {
+        public Dictionary<string, QuestDetail> BuildQuests()
+        {
+            var builder = new QuestBuilder();
+
+            TheCityMustSurvive(builder);
+            ChildrenInTheIce(builder);
+            CoalRunWhiteoutRoute(builder);
+            TheGeneratorCoughs(builder);
+            HeatForTheWards(builder);
+            BlackIceSignal(builder);
+
+            return builder.Build();
+        }
+
+        private void TheCityMustSurvive(QuestBuilder builder)
+        {
+            builder.Create("ark_city_survive", "The City Must Survive")
+                .IsRepeatable()
+
+                .AddState()
+                .SetStateJournalText("Generator Steward Veyra Tann needs fuel and repair stock for the Arkanian Thermal Generator. Bring coal, a heat core, and machine parts back to the generator chamber.")
+                .AddCollectItemObjective(ArkaniaGenerator.CoalResref, 5)
+                .AddCollectItemObjective(ArkaniaGenerator.HeatCoreResref, 1)
+                .AddCollectItemObjective(ArkaniaGenerator.MachinePartResref, 2)
+
+                .AddState()
+                .SetStateJournalText("You delivered emergency supplies for the Arkanian Thermal Generator. Report back to Generator Steward Veyra Tann.")
+
+                .AddGoldReward(1500)
+                .AddXPReward(1000)
+
+                .OnCompleteAction((player, sourceObject) =>
+                {
+                    ArkaniaGenerator.AddCoal(5);
+                    ArkaniaGenerator.AddHeatCores(1);
+                    ArkaniaGenerator.AddMachineParts(2);
+                });
+        }
+
+        private void ChildrenInTheIce(QuestBuilder builder)
+        {
+            builder.Create("ark_children_ice", "Children in the Ice")
+
+                .AddState()
+                .SetStateJournalText("A collapsed mining tunnel has trapped several children beyond the settlement shield line. Reach the first blocked tunnel marker and clear a path.")
+
+                .AddState()
+                .SetStateJournalText("The first obstruction is clear. Stabilize the second tunnel marker before the ice shifts again.")
+
+                .AddState()
+                .SetStateJournalText("The second tunnel marker is secure. Reach the survivor pocket and signal the children to move.")
+
+                .AddState()
+                .SetStateJournalText("The children have been found. Return to the foreman in the settlement before the storm worsens.")
+
+                .AddGoldReward(2250)
+                .AddXPReward(2500)
+                .AddItemReward(ArkaniaGenerator.CoalResref, 3);
+        }
+
+        private void CoalRunWhiteoutRoute(QuestBuilder builder)
+        {
+            builder.Create("ark_coal_run", "Coal Run: Whiteout Route")
+                .IsRepeatable()
+
+                .AddState()
+                .SetStateJournalText("The city needs coal from the exposed mining road. Gather ten coal crates and return them to the generator chamber.")
+                .AddCollectItemObjective(ArkaniaGenerator.CoalResref, 10)
+
+                .AddState()
+                .SetStateJournalText("You recovered coal from the whiteout route. Report back to the generator chamber.")
+
+                .AddGoldReward(1200)
+                .AddXPReward(800)
+
+                .OnCompleteAction((player, sourceObject) =>
+                {
+                    ArkaniaGenerator.AddCoal(10);
+                });
+        }
+
+        private void TheGeneratorCoughs(QuestBuilder builder)
+        {
+            builder.Create("ark_generator_coughs", "The Generator Coughs")
+                .PrerequisiteQuest("ark_city_survive")
+
+                .AddState()
+                .SetStateJournalText("The generator's pressure regulators are failing. Inspect the first gauge cluster in the generator chamber.")
+
+                .AddState()
+                .SetStateJournalText("The first gauge cluster confirms a regulator fault. Inspect the second gauge cluster.")
+
+                .AddState()
+                .SetStateJournalText("The regulator fault is worse than expected. Recover six machine parts from the ruined Arkanian maintenance depot.")
+                .AddCollectItemObjective(ArkaniaGenerator.MachinePartResref, 6)
+
+                .AddState()
+                .SetStateJournalText("You recovered the replacement parts. Install them at the generator console.")
+
+                .AddState()
+                .SetStateJournalText("The generator repairs are complete. Report back to Generator Steward Veyra Tann.")
+
+                .AddGoldReward(3000)
+                .AddXPReward(3500)
+
+                .OnCompleteAction((player, sourceObject) =>
+                {
+                    ArkaniaGenerator.AddMachineParts(6);
+                });
+        }
+
+        private void HeatForTheWards(QuestBuilder builder)
+        {
+            builder.Create("ark_heat_wards", "Heat for the Wards")
+                .IsRepeatable()
+
+                .AddState()
+                .SetStateJournalText("The med ward is running below safe temperature. Bring medical supply packs so the quartermaster can keep the refugees alive.")
+                .AddCollectItemObjective(ArkaniaGenerator.MedicalSuppliesResref, 5)
+
+                .AddState()
+                .SetStateJournalText("You gathered supplies for the med ward. Return to the refugee quartermaster.")
+
+                .AddGoldReward(1000)
+                .AddXPReward(800)
+
+                .OnCompleteAction((player, sourceObject) =>
+                {
+                    ArkaniaGenerator.AddMedicalSupplies(5);
+                });
+        }
+
+        private void BlackIceSignal(QuestBuilder builder)
+        {
+            builder.Create("ark_black_ice_signal", "Black Ice Signal")
+                .PrerequisiteQuest("ark_children_ice")
+
+                .AddState()
+                .SetStateJournalText("An old Arkanian transmitter is still broadcasting through the storm. Reach the buried relay and recover forecast data.")
+                .AddCollectItemObjective(ArkaniaGenerator.ForecastDataResref, 3)
+
+                .AddState()
+                .SetStateJournalText("You recovered forecast data from the buried relay. Return it to the generator chamber so the city can predict the next whiteout.")
+
+                .AddGoldReward(2500)
+                .AddXPReward(3000)
+
+                .OnCompleteAction((player, sourceObject) =>
+                {
+                    ArkaniaGenerator.AddForecastData(3);
+                });
+        }
+    }
+}

--- a/SWLOR.Game.Server/Readmes/ArkaniaSurvivalPlan.md
+++ b/SWLOR.Game.Server/Readmes/ArkaniaSurvivalPlan.md
@@ -1,0 +1,312 @@
+# Arkania Survival Project Plan
+
+## Scope and guardrails
+
+This plan keeps the Arkania survival concept close to SWLOR's existing patterns instead of introducing a large custom rules engine. The goal is to make the cold dangerous and memorable while reusing familiar systems:
+
+- **Planet setup**: add Arkania as a normal `PlanetType` entry, with area names following the existing `"PlanetName - AreaName"` convention.
+- **Weather**: extend the current `Weather` service and `WeatherClimate` data instead of creating a separate survival tick system.
+- **Quests**: define content through a normal `Feature/QuestDefinition/ArkaniaQuestDefinition.cs` using `QuestBuilder` states, kill objectives, collect objectives, repeatable quests, and object-use progression.
+- **Generator resources**: store one city-level entity in Redis and expose it through a single NPC/dialog or NUI, avoiding area-by-area persistence or per-player global state.
+- **Theme fit**: use KOTOR-era Arkania, Republic/Old Sith tension, Arkanian scientists, offshoot miners, droids, mercenaries, and ancient machinery. Avoid direct Frostpunk names, factions, laws, or modern steampunk references.
+
+## Existing systems to build on
+
+| Need | Existing code pattern | Recommended Arkania use |
+| --- | --- | --- |
+| Planet identity | `PlanetType` entries define planet name, area prefix, orbit waypoint, landing waypoint, fee, and active flag. | Add `Arkania = 256` with `"Arkania - "`, `Arkania_Orbit`, and `ARKANIA_LANDING`. |
+| Climate by planet name | `Weather.GetAreaClimate` parses the area name before the hyphen and looks up `WeatherPlanetDefinitions`. | Arkania outdoor areas named `Arkania - Frozen Causeway` automatically inherit Arkania climate. |
+| Snowstorm damage | `Weather.DoWeatherEffects` already checks `SNOW_STORM` and applies recurring cold damage through `ApplySnowstorm`. | Use existing snowstorms as the first playable hazard before adding new freeze-depth mechanics. |
+| Quest structure | Planet quest files use `IQuestListDefinition` and `QuestBuilder` with states, rewards, prerequisites, repeatables, and callbacks. | Keep Arkania quests in one planet quest definition until content volume justifies splitting. |
+| Persistent server state | `DB.Get<T>` / `DB.Set` already persist entities such as module cache, players, properties, and accounts. | Add one `ArkaniaGeneratorState` entity keyed to `ARKANIA_GENERATOR` for heat, coal, parts, and storm state. |
+
+## Arkania quest package
+
+The first release should be a compact vertical slice: one settlement hub, one mine/cave, one exterior route, one generator chamber, and one storm-safe interior. The quests below are designed to share props and objective locations so the build does not balloon.
+
+### 1. The City Must Survive
+
+- **Type**: repeatable community turn-in / generator contribution.
+- **NPC**: Generator Steward Veyra Tann, placed near the generator console.
+- **Objectives**:
+  - Turn in `ark_coal`, `ark_heat_core`, or `ark_machine_part`.
+  - Update the shared generator stockpile.
+  - Reward credits, XP, and a small survival token/city scrip item.
+- **Implementation fit**:
+  - Use a collect-item quest for the first iteration.
+  - Later, move the turn-in to a dialog/NUI that directly calls `DB.Get<ArkaniaGeneratorState>` and `DB.Set`.
+- **Flavor**: players are not saving the world; they are buying the city another day.
+
+### 2. Children in the Ice
+
+- **Type**: rescue/object-use chain.
+- **Location**: collapsed frozen mining tunnel.
+- **Objectives**:
+  1. Speak to a foreman at the settlement.
+  2. Activate three blocked tunnel markers to clear ice or stabilize beams.
+  3. Escort or locate trapped children/survivors.
+  4. Return to the foreman.
+- **Implementation fit**:
+  - Use quest states with object-use advancement like existing object-based quests.
+  - Use visibility toggles for trapped survivor NPCs if needed.
+- **Weather tie-in**: tunnel mouth can be an exterior area with snowstorm risk; inner tunnel is safe from weather but contains hostile creatures or failing machinery.
+
+### 3. Coal Run: Whiteout Route
+
+- **Type**: repeatable collection route.
+- **Location**: exterior road from city to old mining depot.
+- **Objectives**:
+  - Gather coal crates from exposed waypoints or placeables.
+  - Return before or during a storm.
+- **Implementation fit**:
+  - Start as `AddCollectItemObjective("ark_coal", quantity)`.
+  - Add random crate respawns later through existing spawn/placeable scripts.
+- **Reward hook**: higher reward if the generator heat is critically low.
+
+### 4. The Generator Coughs
+
+- **Type**: generator repair quest.
+- **Prerequisites**: one or more basic city quests.
+- **Objectives**:
+  1. Inspect pressure gauges.
+  2. Recover machine parts from a ruined Arkanian facility.
+  3. Defeat sabotage droids or scavengers.
+  4. Install the parts at the generator console.
+- **Implementation fit**:
+  - Combine object-use quest states with a kill objective and collect objective.
+  - On completion, add a fixed amount of generator integrity.
+- **KOTOR-era flavor**: the generator is old Republic/Arkanian thermal infrastructure, not a Frostpunk steam core.
+
+### 5. Heat for the Wards
+
+- **Type**: moral/community support quest.
+- **NPCs**: med ward doctor, refugee quartermaster.
+- **Objectives**:
+  - Deliver insulated blankets, medpacs, and food packs.
+  - Optional: redirect limited generator reserve to the ward for a temporary morale/medical reward.
+- **Implementation fit**:
+  - Keep the first pass as a normal collect quest.
+  - Later, tie optional choices to generator state by increasing `Morale` or decreasing `HeatReserve`.
+- **Tone**: survival choices should be grim, but not copy Frostpunk law systems.
+
+### 6. Black Ice Signal
+
+- **Type**: exploration and combat.
+- **Location**: ancient transmitter half-buried in ice.
+- **Objectives**:
+  - Track distress pings during storm windows.
+  - Clear wildlife or old security droids.
+  - Restore the signal to improve city forecasts.
+- **Implementation fit**:
+  - Completion can unlock stronger storm warnings from the generator NPC.
+  - This gives a lore reason for better player-facing weather messages.
+
+### 7. Saboteurs in the White
+
+- **Type**: escalating repeatable/event quest.
+- **Enemies**: mercenaries, Sith-aligned agents, or industrial rivals trying to seize Arkanian tech.
+- **Objectives**:
+  - Defend fuel sleds or generator maintenance crews.
+  - Kill attackers and recover stolen parts.
+- **Implementation fit**:
+  - Use kill objectives and stolen-part collect objectives.
+  - Use as a later-phase quest after the simple generator loop is stable.
+
+## Generator resource concept
+
+### Name
+
+**The Arkanian Thermal Generator**
+
+This should feel like a KOTOR-era planetary survival system: geothermal taps, ionized heat exchangers, Republic-era regulators, Arkanian cold-weather engineering, and fragile ancient infrastructure.
+
+### Player-facing resources
+
+| Resource | Item resref suggestion | Use |
+| --- | --- | --- |
+| Coal / thermal ore | `ark_coal` | Basic fuel; common from mines and exterior routes. |
+| Machine parts | `ark_machine_part` | Repairs integrity decay and storm damage. |
+| Heat cores | `ark_heat_core` | Rare high-value fuel from facilities, bosses, or hard quests. |
+| Medical supplies | `ark_med_supplies` | Optional city morale/ward support. |
+| Forecast data | `ark_forecast_data` | Optional unlock for improved warning text or reduced surprise storms. |
+
+### Server state entity sketch
+
+Add this only when the first quest loop works. Until then, use collect quests and rewards to validate fun.
+
+```csharp
+public class ArkaniaGeneratorState : EntityBase
+{
+    public ArkaniaGeneratorState()
+    {
+        Id = "ARKANIA_GENERATOR";
+    }
+
+    public int HeatReserve { get; set; }
+    public int Integrity { get; set; } = 100;
+    public int Coal { get; set; }
+    public int MachineParts { get; set; }
+    public int HeatCores { get; set; }
+    public int Morale { get; set; } = 50;
+    public DateTime LastProcessed { get; set; } = DateTime.UtcNow;
+}
+```
+
+### Generator behavior
+
+- **HeatReserve** is the primary score players see.
+- **Integrity** controls how efficiently fuel converts into heat.
+- **Coal** is consumed first.
+- **Heat cores** are emergency fuel.
+- **Machine parts** repair integrity.
+- **Morale** is optional and should not block core functionality in the first pass.
+
+Recommended first-pass thresholds:
+
+| Generator condition | HeatReserve | Gameplay effect |
+| --- | ---: | --- |
+| Stable | 70+ | Normal city, standard exterior weather. |
+| Strained | 40-69 | More warning text, no extra damage yet. |
+| Failing | 15-39 | Exterior storm damage can be slightly more frequent. |
+| Critical | 0-14 | City NPC warnings, emergency quests highlighted, storm damage allowed near city outskirts. |
+
+Keep the first implementation passive: the generator changes messages, rewards, and storm severity. Do not immediately make the city unusable or kill players in safe hub interiors.
+
+## Weather coding plan
+
+### Step 1: planet climate only
+
+Add an Arkania climate entry patterned after Hutlar, but tune it as its own world:
+
+```csharp
+[PlanetType.Arkania] = new WeatherClimate
+{
+    HeatModifier = -9,
+    HumidityModifier = -2,
+    WindModifier = +2,
+    HasSnowStorms = true,
+    FreezingText = "The Arkanian cold bites through exposed seams in your gear.",
+    SnowText = "Fine ice falls like dust, whitening every exposed surface.",
+    WindyText = "A hard polar wind drags loose snow across the ground.",
+    ColdWindyText = "The wind cuts like a vibroblade, numbing exposed flesh.",
+    StormText = "A whiteout swallows the horizon; only the generator lights feel real."
+};
+```
+
+This uses current climate modifiers and `HasSnowStorms`, keeping Arkania inside the existing weather framework.
+
+### Step 2: use existing snowstorm damage
+
+The current system already damages PCs during `SNOW_STORM` with `d6(2)` cold damage every 6 seconds via `ApplySnowstorm`. For the initial Arkania test, prefer that existing behavior over a new survival meter.
+
+Recommended rule:
+
+- **Interior or underground areas**: no weather damage.
+- **Outdoor hub outskirts**: snowstorm visuals and warning text, but no damage until players leave safe boundaries.
+- **Wilderness and mine exterior**: normal `SNOW_STORM` damage.
+- **Deep storm expedition areas**: optional stronger damage after the base system is accepted.
+
+### Step 3: small Arkania-specific cold helper
+
+Only add this if Zunath is comfortable with a planet-specific branch. The function should remain tiny and reuse NWScript effects.
+
+```csharp
+private static void ApplyArkaniaCold(uint target, uint area, int severity)
+{
+    if (GetArea(target) != area) return;
+    if (GetIsDead(target)) return;
+    if (GetIsPC(target) && GetIsPC(GetMaster(target)) == false) return;
+
+    var damage = severity <= 1 ? d4() : d6(severity);
+    var effect = EffectLinkEffects(
+        EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
+        EffectDamage(damage, DamageType.Cold));
+
+    ApplyEffectToObject(DurationType.Instant, effect, target);
+    DelayCommand(6.0f, () => ApplyArkaniaCold(target, area, severity));
+}
+```
+
+Suggested safety checks before applying it:
+
+- Area planet must be Arkania.
+- Area local int `ARKANIA_SAFE_FROM_COLD` must not be `1`.
+- Player should be above ground and outside.
+- Severity should be capped to `1` or `2` for the first release.
+
+### Step 4: generator influences weather severity
+
+When `ArkaniaGeneratorState.HeatReserve` exists, use it lightly:
+
+```csharp
+var generator = DB.Get<ArkaniaGeneratorState>("ARKANIA_GENERATOR") ?? new ArkaniaGeneratorState();
+var severity = generator.HeatReserve < 15 ? 2 : 1;
+```
+
+Do not make the generator directly drive the whole planet weather table at first. Let it adjust local severity and warning messages only.
+
+## NPC/dialog plan
+
+### Generator Steward Veyra Tann
+
+Dialogue options:
+
+1. **"How is the Generator holding?"**
+   - Shows HeatReserve, Integrity, Coal, MachineParts, and HeatCores in simple text.
+2. **"I brought fuel."**
+   - Consumes `ark_coal` or `ark_heat_core` and updates stockpiles.
+3. **"I brought repair parts."**
+   - Consumes `ark_machine_part` and improves Integrity.
+4. **"Where can I help?"**
+   - Points to currently relevant repeatable quests.
+5. **"What happens if the Generator fails?"**
+   - Lore explanation and warning, not a hard fail-state in the first version.
+
+Keep the NPC on Viscara only if this is a cross-planet test console. For the real feature, place Veyra in Arkania's settlement so the system feels diegetic.
+
+## Suggested implementation phases
+
+### Phase 1: vertical slice
+
+- Add `PlanetType.Arkania`.
+- Add Arkania climate in `WeatherPlanetDefinitions`.
+- Build one exterior area and one safe interior.
+- Add two quests:
+  - `ark_city_survive`
+  - `ark_children_ice`
+- Use current snowstorm weather damage.
+
+### Phase 2: resource loop
+
+- Add `ArkaniaGeneratorState`.
+- Add Steward Veyra dialog for status and item contribution.
+- Add coal and part item resrefs.
+- Add `ark_coal_run` repeatable.
+
+### Phase 3: consequences and escalation
+
+- Generator condition changes storm warnings and optional severity.
+- Add `ark_generator_coughs` and `ark_saboteurs_white`.
+- Add rewards for community contributors.
+- Add improved forecasts after `ark_black_ice_signal`.
+
+## Zunath concern checklist
+
+Before implementation, confirm these items:
+
+- Does the project want Arkania active immediately, or hidden until areas/waypoints are ready?
+- Should generator resources be global across the server or reset weekly/event-style?
+- What are acceptable damage numbers for low-level players in weather areas?
+- Should city hub interiors always be safe from cold damage?
+- Should the first version avoid new GUI and rely on dialog text?
+- Which existing item resrefs should be reused for coal/parts, if any, before adding new item blueprints?
+
+## Recommended minimum code changes
+
+For the smallest code footprint, start with only these:
+
+1. Add `Arkania = 256` to `PlanetType`.
+2. Add `[PlanetType.Arkania]` to `WeatherPlanetDefinitions`.
+3. Add `ArkaniaQuestDefinition.cs` with two quests.
+4. Add a simple dialog later for generator status.
+5. Reuse `SNOW_STORM` and `ApplySnowstorm` until player feedback proves a custom Arkania cold tick is needed.

--- a/SWLOR.Game.Server/Readmes/README.md
+++ b/SWLOR.Game.Server/Readmes/README.md
@@ -4,6 +4,15 @@ This folder contains comprehensive documentation for the SWLOR.Game.Server proje
 
 ## Available Documentation
 
+
+### [ArkaniaSurvivalPlan.md](ArkaniaSurvivalPlan.md)
+A focused implementation plan for an Arkania survival project inspired by grim cold-weather survival themes while staying inside SWLOR's existing KOTOR-era systems. This includes:
+
+- **Quest package ideas** for rescue, fuel gathering, generator repairs, and storm expeditions
+- **Weather implementation notes** that reuse the existing climate and snowstorm damage systems
+- **Generator resource design** with a small persistent state entity sketch
+- **Implementation phases and guardrails** to keep the feature from becoming too large too early
+
 ### [Builders.md](Builders.md)
 Comprehensive documentation of all builder classes in the SWLOR.Game.Server project. This includes:
 

--- a/SWLOR.Game.Server/Service/ArkaniaGenerator.cs
+++ b/SWLOR.Game.Server/Service/ArkaniaGenerator.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using SWLOR.Game.Server.Entity;
+
+namespace SWLOR.Game.Server.Service
+{
+    public static class ArkaniaGenerator
+    {
+        public const string GeneratorId = "ARKANIA_GENERATOR";
+        public const string CoalResref = "ark_coal";
+        public const string MachinePartResref = "ark_machine_part";
+        public const string HeatCoreResref = "ark_heat_core";
+        public const string MedicalSuppliesResref = "ark_med_supplies";
+        public const string ForecastDataResref = "ark_forecast_data";
+
+        private const int MaximumHeatReserve = 100;
+        private const int MaximumIntegrity = 100;
+        private const int MaximumMorale = 100;
+
+        public static ArkaniaGeneratorState GetState()
+        {
+            var state = DB.Get<ArkaniaGeneratorState>(GeneratorId);
+            if (state != null)
+                return state;
+
+            state = new ArkaniaGeneratorState();
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static ArkaniaGeneratorState AddCoal(int amount)
+        {
+            var safeAmount = Math.Max(0, amount);
+            var state = GetState();
+            state.Coal += safeAmount;
+            state.HeatReserve = Math.Min(MaximumHeatReserve, state.HeatReserve + safeAmount);
+            state.LastUpdated = DateTime.UtcNow;
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static ArkaniaGeneratorState AddHeatCores(int amount)
+        {
+            var safeAmount = Math.Max(0, amount);
+            var state = GetState();
+            state.HeatCores += safeAmount;
+            state.HeatReserve = Math.Min(MaximumHeatReserve, state.HeatReserve + safeAmount * 10);
+            state.LastUpdated = DateTime.UtcNow;
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static ArkaniaGeneratorState AddMachineParts(int amount)
+        {
+            var safeAmount = Math.Max(0, amount);
+            var state = GetState();
+            state.MachineParts += safeAmount;
+            state.Integrity = Math.Min(MaximumIntegrity, state.Integrity + safeAmount * 5);
+            state.LastUpdated = DateTime.UtcNow;
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static ArkaniaGeneratorState AddMedicalSupplies(int amount)
+        {
+            var safeAmount = Math.Max(0, amount);
+            var state = GetState();
+            state.MedicalSupplies += safeAmount;
+            state.Morale = Math.Min(MaximumMorale, state.Morale + safeAmount * 2);
+            state.LastUpdated = DateTime.UtcNow;
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static ArkaniaGeneratorState AddForecastData(int amount)
+        {
+            var safeAmount = Math.Max(0, amount);
+            var state = GetState();
+            state.ForecastData += safeAmount;
+            state.LastUpdated = DateTime.UtcNow;
+            DB.Set(state);
+
+            return state;
+        }
+
+        public static string GetCondition(ArkaniaGeneratorState state)
+        {
+            if (state.HeatReserve >= 70) return "Stable";
+            if (state.HeatReserve >= 40) return "Strained";
+            if (state.HeatReserve >= 15) return "Failing";
+
+            return "Critical";
+        }
+
+        public static string BuildStatusText()
+        {
+            var state = GetState();
+            return
+                $"Condition: {GetCondition(state)}\n" +
+                $"Heat Reserve: {state.HeatReserve}/100\n" +
+                $"Integrity: {state.Integrity}/100\n" +
+                $"Coal Stockpile: {state.Coal}\n" +
+                $"Machine Parts: {state.MachineParts}\n" +
+                $"Heat Cores: {state.HeatCores}\n" +
+                $"Medical Supplies: {state.MedicalSupplies}\n" +
+                $"Forecast Data: {state.ForecastData}\n" +
+                $"Morale: {state.Morale}/100";
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/Weather.cs
+++ b/SWLOR.Game.Server/Service/Weather.cs
@@ -329,23 +329,44 @@ namespace SWLOR.Game.Server.Service
             DelayCommand(6.0f, () => { ApplySandstorm(oTarget, oArea); });
         }
 
-        public static void ApplySnowstorm(uint oTarget, uint oArea)
+        public static void ApplySnowstorm(uint oTarget, uint oArea, int damageDice = 2)
         {
             if (GetArea(oTarget) != oArea) return;
             if (GetIsDead(oTarget)) return;
             if (GetIsPC(oTarget) && GetIsPC(GetMaster(oTarget)) == false) return;
+
+            if (damageDice <= 0) return;
+            damageDice = Math.Clamp(damageDice, 1, 3);
 
             //apply
             var eEffect =
                 EffectLinkEffects(
                     EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
                     EffectDamage(
-                        d6(2),
+                        d6(damageDice),
                         DamageType.Cold));
 
             ApplyEffectToObject(DurationType.Instant, eEffect, oTarget);
 
-            DelayCommand(6.0f, () => { ApplySnowstorm(oTarget, oArea); });
+            DelayCommand(6.0f, () => { ApplySnowstorm(oTarget, oArea, damageDice); });
+        }
+
+        private static int GetSnowstormDamageDice(uint oArea)
+        {
+            if (!GetName(oArea).StartsWith("Arkania - ", StringComparison.Ordinal))
+                return 2;
+
+            if (GetLocalInt(oArea, "ARKANIA_SAFE_FROM_COLD") == 1)
+                return 0;
+
+            var generator = ArkaniaGenerator.GetState();
+            if (generator.HeatReserve < 15)
+                return 3;
+
+            if (generator.HeatReserve >= 70)
+                return 1;
+
+            return 2;
         }
 
         public static void DoWeatherEffects(uint oCreature)
@@ -396,16 +417,20 @@ namespace SWLOR.Game.Server.Service
             }
             else if (bIsPC && GetLocalInt(oArea, "SNOW_STORM") == 1)
             {
-                var eEffect =
-                    EffectLinkEffects(
-                        EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
-                        EffectDamage(
-                            d6(2),
-                            DamageType.Cold));
+                var damageDice = GetSnowstormDamageDice(oArea);
+                if (damageDice > 0)
+                {
+                    var eEffect =
+                        EffectLinkEffects(
+                            EffectVisualEffect(VisualEffect.Vfx_Dur_Iceskin),
+                            EffectDamage(
+                                d6(damageDice),
+                                DamageType.Cold));
 
-                ApplyEffectToObject(DurationType.Instant, eEffect, oCreature);
+                    ApplyEffectToObject(DurationType.Instant, eEffect, oCreature);
 
-                DelayCommand(6.0f, () => { ApplySnowstorm(oCreature, oArea); });
+                    DelayCommand(6.0f, () => { ApplySnowstorm(oCreature, oArea, damageDice); });
+                }
             }
             else if (bIsPC)
             {

--- a/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
+++ b/SWLOR.Game.Server/Service/WeatherService/WeatherPlanetDefinitions.cs
@@ -64,6 +64,21 @@ namespace SWLOR.Game.Server.Service.WeatherService
                     MildText = "It is cold, the sky is clear, and there is a gentle breeze.",
                     WarmCloudyText = "It is cold."
                 },
+                [PlanetType.Arkania] = new WeatherClimate
+                {
+                    HeatModifier = -9,
+                    HumidityModifier = -2,
+                    WindModifier = +2,
+                    HasSnowStorms = true,
+                    FreezingText = "The Arkanian cold bites through exposed seams in your gear.",
+                    SnowText = "Fine ice falls like dust, whitening every exposed surface.",
+                    WindyText = "A hard polar wind drags loose snow across the ground.",
+                    ColdWindyText = "The wind cuts like a vibroblade, numbing exposed flesh.",
+                    CloudyText = "Low clouds press over the ice, trapping the generator's glow under a gray ceiling.",
+                    ColdCloudyText = "Heavy cloud cover holds the cold close, and every gust feels sharper than the last.",
+                    MildText = "The air is bitter, but calm enough that the city can breathe for a moment.",
+                    StormText = "A whiteout swallows the horizon; only the generator lights feel real."
+                },
                 [PlanetType.Korriban] = new WeatherClimate
                 {
                     HeatModifier = +3,


### PR DESCRIPTION
### Motivation

- Introduce an Arkania-themed survival feature consisting of a world climate, a shared thermal generator resource, player contribution quests, and an NPC dialog to manage contributions. 
- Reuse existing systems (weather, quests, persistence) to keep the scope small and consistent with current code patterns. 
- Make weather severity optionally influenced by a single server-side `ArkaniaGeneratorState` to provide light gameplay consequences without a full custom rules engine. 

### Description

- Add a persistent entity `ArkaniaGeneratorState` (`SWLOR.Game.Server/Entity/ArkaniaGeneratorState.cs`) and a service `ArkaniaGenerator` (`SWLOR.Game.Server/Service/ArkaniaGenerator.cs`) to track heat, stockpiles, integrity, morale, and last-updated timestamps. 
- Add quest definitions in `ArkaniaQuestDefinition.cs` to provide the initial set of Arkania repeatable and progression quests that feed the generator via `QuestBuilder` callbacks. 
- Add a dialog `ArkaniaGeneratorDialog.cs` to allow players to deposit items from inventory into the generator and view status text, including helper methods to count/remove stacked items. 
- Integrate Arkania into weather systems by adding an `Arkania` `PlanetType` entry (inactive by default) and a new `WeatherClimate` for Arkania in `WeatherPlanetDefinitions.cs`. 
- Update `Weather.cs` to vary `SNOW_STORM` cold damage by area and generator heat via a new `GetSnowstormDamageDice` helper and by changing `ApplySnowstorm` to accept a `damageDice` parameter; `SNOW_STORM` damage is skipped for areas flagged with `ARKANIA_SAFE_FROM_COLD`. 
- Add documentation `Readmes/ArkaniaSurvivalPlan.md` and link it from `Readmes/README.md` describing scope, design decisions, and implementation phases. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022cc80a3c8329b899ef6ac52191e7)