### PR TITLE
Nar Shaddaa: fix loot table refs, remove duplicate emerald, adjust dragon spawn and quest condition

### DIFF
--- a/Module/dlg/gsiquest1.dlg.json
+++ b/Module/dlg/gsiquest1.dlg.json
@@ -1369,7 +1369,7 @@
               },
               "Value": {
                 "type": "cexostring",
-                "value": "nar_great_arkanian_dragon 2"
+                "value": "nar_great_arkanian_dragon 2 3"
               }
             }
           ]

--- a/Module/utc/nar_arenafight.utc.json
+++ b/Module/utc/nar_arenafight.utc.json
@@ -155,7 +155,7 @@
   "Description": {
     "type": "cexolocstring",
     "value": {
-      "0": "A hardened arena combatant from Nar Shaddaa’s underground pits. Built for spectacle and survival, this fighter is relentless in close combat."
+      "0": "A hardened arena combatant from Nar Shaddaaâ€™s underground pits. Built for spectacle and survival, this fighter is relentless in close combat."
     }
   },
   "Dex": {
@@ -674,7 +674,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_hiddenblade.utc.json
+++ b/Module/utc/nar_hiddenblade.utc.json
@@ -688,7 +688,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_pirate.utc.json
+++ b/Module/utc/nar_pirate.utc.json
@@ -703,7 +703,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_redblade.utc.json
+++ b/Module/utc/nar_redblade.utc.json
@@ -688,7 +688,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_serpent.utc.json
+++ b/Module/utc/nar_serpent.utc.json
@@ -681,7 +681,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_thief.utc.json
+++ b/Module/utc/nar_thief.utc.json
@@ -681,7 +681,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/Module/utc/nar_troublemaker.utc.json
+++ b/Module/utc/nar_troublemaker.utc.json
@@ -681,7 +681,7 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
-          "value": "LOOT_TABLE_3"
+          "value": "LOOT_TABLE_2"
         },
         "Type": {
           "type": "dword",

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/NarShaddaaLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/NarShaddaaLootTableDefinition.cs
@@ -170,7 +170,6 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
 				.IsRare()
 				.AddItem("ns_holo_jelly", 1, 1, true)
 				.AddItem("emerald", 1, 1, true)
-				.AddItem("emerald", 1, 1, true)
 				.AddItem("map_82", 2, 1, true)
 				.AddItem("map_83", 2, 1, true)
 				.AddItem("map_84", 2, 1, true)

--- a/SWLOR.Game.Server/Feature/SpawnDefinition/NarShaddaaSpawnDefinition.cs
+++ b/SWLOR.Game.Server/Feature/SpawnDefinition/NarShaddaaSpawnDefinition.cs
@@ -148,7 +148,6 @@ namespace SWLOR.Game.Server.Feature.SpawnDefinition
                 .AddSpawn(ObjectType.Creature, "garkaniandragon")
                 .WithFrequency(1)
                 .RandomlyWalks()
-                .WithFrequency(100)
                 .ReturnsHome();
         }
         private void DragonLoot()


### PR DESCRIPTION
### Motivation
- Correct inconsistent loot table variable names in creature UTCs so spawns use the intended loot definitions.
- Remove a duplicate rare drop entry and fix spawn frequency duplication to prevent incorrect loot/spawn behavior.
- Broaden a quest-state dialog condition to include an additional state for the Great Arkanian Dragon quest.

### Description
- Changed the dialog condition value in `Module/dlg/gsiquest1.dlg.json` to include an additional state (`"nar_great_arkanian_dragon 2 3"`).
- Renamed the VarTable entries from `LOOT_TABLE_3` to `LOOT_TABLE_2` across multiple UTC files (for example `nar_arenafight.utc.json`, `nar_hiddenblade.utc.json`, `nar_pirate.utc.json`, `nar_redblade.utc.json`, `nar_serpent.utc.json`, `nar_thief.utc.json`, and `nar_troublemaker.utc.json`).
- Removed a duplicated `AddItem("emerald", 1, 1, true)` call in `NarShaddaaLootTableDefinition.cs` to eliminate duplicate rare drop entries.
- Removed a redundant `.WithFrequency(100)` call from the `GreatArkanianDragon` spawn definition in `NarShaddaaSpawnDefinition.cs` to ensure the intended spawn frequency is used.

### Testing
- Built the solution and ran the automated unit test suite, and all tests completed successfully.
- Verified that the modified UTC/JSON files were validly updated by the automated build step without parsing errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ae72cf5c8329992ebbe9608ffd6d)