### PR TITLE
Fix GSI dragon quest dialogue states

### DIFF
--- a/Module/dlg/gsiquest1.dlg.json
+++ b/Module/dlg/gsiquest1.dlg.json
@@ -484,11 +484,23 @@
               "__struct_id": 0,
               "Active": {
                 "type": "resref",
-                "value": ""
+                "value": "condition"
               },
               "ConditionParams": {
                 "type": "list",
-                "value": []
+                "value": [
+                  {
+                    "__struct_id": 0,
+                    "Key": {
+                      "type": "cexostring",
+                      "value": "condition-on-quest-state"
+                    },
+                    "Value": {
+                      "type": "cexostring",
+                      "value": "nar_great_arkanian_dragon 2"
+                    }
+                  }
+                ]
               },
               "Index": {
                 "type": "dword",
@@ -503,11 +515,23 @@
               "__struct_id": 1,
               "Active": {
                 "type": "resref",
-                "value": ""
+                "value": "condition"
               },
               "ConditionParams": {
                 "type": "list",
-                "value": []
+                "value": [
+                  {
+                    "__struct_id": 0,
+                    "Key": {
+                      "type": "cexostring",
+                      "value": "condition-on-quest-state"
+                    },
+                    "Value": {
+                      "type": "cexostring",
+                      "value": "nar_great_arkanian_dragon 1"
+                    }
+                  }
+                ]
               },
               "Index": {
                 "type": "dword",
@@ -1369,7 +1393,7 @@
               },
               "Value": {
                 "type": "cexostring",
-                "value": "nar_great_arkanian_dragon 2 3"
+                "value": "nar_great_arkanian_dragon 3"
               }
             }
           ]


### PR DESCRIPTION
### Motivation
- Prevent players from accessing the trophy turn-in flow before they have the proof (dragon head) and ensure the reward/conclusion dialogue only appears after the trophy has been turned in.
- Correct dialogue gating so replies map cleanly to the intended quest states for the Great Arkanian Dragon hunt.

### Description
- Update `Module/dlg/gsiquest1.dlg.json` to gate the "It's done. The beast is dead." reply behind `condition-on-quest-state nar_great_arkanian_dragon 2` so the turn-in only appears when the player is on state 2.
- Gate the "Ah! Not yet." reply behind `condition-on-quest-state nar_great_arkanian_dragon 1` so it only appears for players still on state 1.
- Change the starting/route condition from `nar_great_arkanian_dragon 2 3` to `nar_great_arkanian_dragon 3` so the reward/conclusion dialogue is only reachable on state 3 after the trophy has been turned in.

### Testing
- Ran `python -m json.tool Module/dlg/gsiquest1.dlg.json >/tmp/gsiquest1.json` to validate JSON formatting; succeeded.
- Ran `git diff --check` to ensure no trailing whitespace or diff issues; no problems found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05064cfc28832991f80a17f6a7d41c)