### PR TITLE
Add guaranteed stolen goods loot to ancient sandworm

### DIFF
--- a/Module/utc/ancientsandwor.utc.json
+++ b/Module/utc/ancientsandwor.utc.json
@@ -636,6 +636,21 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
+          "value": "LOOT_TABLE_7"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "TATOOINE_ANCIENT_WORM_STOLEN_GOODS,100,5"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
           "value": "QUEST_NPC_GROUP_ID"
         },
         "Type": {

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/TatooineLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/TatooineLootTableDefinition.cs
@@ -164,11 +164,12 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
                 .AddItem("wild_meat", 10)
                 .AddItem("wild_innards", 10)
                 .AddItem("sandwormtooth", 5)
-                .AddItem("chiro_shard", 1)
-                .AddItem("stolen_goods", 50);
+                .AddItem("chiro_shard", 1);
 
+            _builder.Create("TATOOINE_ANCIENT_WORM_STOLEN_GOODS")
+                .AddItem("stolen_goods", 100);
 
-			_builder.Create("TATOOINE_ANCIENT_WORM_GEMS")
+            _builder.Create("TATOOINE_ANCIENT_WORM_GEMS")
                 .AddItem("emerald", 100, 1, true)
                 .AddItem("chiro_shard", 50, 1, true);
 


### PR DESCRIPTION
### Motivation
- The smuggler quest requires five `stolen_goods` after a single `Tatooine_AncientSandworm` kill, but the previous loot configuration could only yield at most two, preventing natural quest progression. 

### Description
- Removed `stolen_goods` from the `TATOOINE_ANCIENT_WORM` loot table and added a dedicated `TATOOINE_ANCIENT_WORM_STOLEN_GOODS` loot table that contains `stolen_goods` with a high frequency. 
- Attached `TATOOINE_ANCIENT_WORM_STOLEN_GOODS` to the ancient sandworm UTC as `TATOOINE_ANCIENT_WORM_STOLEN_GOODS,100,5` so the single required worm kill will produce five guaranteed `stolen_goods`. 
- Modified files: `SWLOR.Game.Server/Feature/LootTableDefinition/TatooineLootTableDefinition.cs` and `Module/utc/ancientsandwor.utc.json`.

### Testing
- `python -m json.tool Module/utc/ancientsandwor.utc.json` succeeded and validated the modified UTC JSON. 
- `git diff --check` succeeded with no whitespace or diff errors. 
- `dotnet test SWLOR.Game.Server.sln` was not executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a051e2b45b0832986cf913fcdbc8e5f)