### PR TITLE
Guarantee Arkanian dragon trophy drop

### DIFF
--- a/Module/utc/garkaniandragon.utc.json
+++ b/Module/utc/garkaniandragon.utc.json
@@ -689,6 +689,21 @@
         "__struct_id": 0,
         "Name": {
           "type": "cexostring",
+          "value": "LOOT_TABLE_5"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 3
+        },
+        "Value": {
+          "type": "cexostring",
+          "value": "NARSHADDAA_GREAT_ARKANIAN_DRAGON_TROPHY,100,1"
+        }
+      },
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
           "value": "QUEST_NPC_GROUP_ID"
         },
         "Type": {

--- a/SWLOR.Game.Server/Feature/LootTableDefinition/NarShaddaaLootTableDefinition.cs
+++ b/SWLOR.Game.Server/Feature/LootTableDefinition/NarShaddaaLootTableDefinition.cs
@@ -251,8 +251,10 @@ namespace SWLOR.Game.Server.Feature.LootTableDefinition
 				.AddItem("wild_meat", 15)
 				.AddItem("ns_rack_meat", 15)
 				.AddItem("chiro_shard", 2)
-				.AddItem("ark_dragon_troph", 100)
 				.AddGold(300, 40);
+
+			_builder.Create("NARSHADDAA_GREAT_ARKANIAN_DRAGON_TROPHY")
+				.AddItem("ark_dragon_troph", 100);
 
 			_builder.Create("NARSHADDAA_GREAT_ARKANIAN_DRAGON_GEMS")
 				.AddItem("emerald", 100, 1, true)


### PR DESCRIPTION
### Motivation
- The Great Arkanian Dragon quest requires the `ark_dragon_troph` trophy but the trophy was only present as a weighted entry in the dragon's main loot pool, making quest progression unreliable.
- Ensure players reliably obtain the trophy when appropriate by making the trophy a guaranteed roll rather than a low-weight random outcome.

### Description
- Added a dedicated loot table `NARSHADDAA_GREAT_ARKANIAN_DRAGON_TROPHY` in `SWLOR.Game.Server/Feature/LootTableDefinition/NarShaddaaLootTableDefinition.cs` that contains `ark_dragon_troph` as a guaranteed entry.
- Removed the trophy as a weighted `AddItem` in the main `NARSHADDAA_GREAT_ARKANIAN_DRAGON` pool so it is not only a random option there.
- Updated `Module/utc/garkaniandragon.utc.json` to add `LOOT_TABLE_5` that references `NARSHADDAA_GREAT_ARKANIAN_DRAGON_TROPHY,100,1` so the creature rolls the trophy table at 100%.
- Kept existing gem and rare tables intact and ensured the new trophy table is referenced by the dragon's loot variables.

### Testing
- Parsed `Module/utc/garkaniandragon.utc.json` as JSON to validate syntax, which succeeded.
- Ran validation scripts to confirm that the new `NARSHADDAA_GREAT_ARKANIAN_DRAGON_TROPHY` table is referenced by the dragon UTC entries and that Nar Shaddaa quest, loot, and spawn resrefs resolve to module resources, which all succeeded.
- Attempted `dotnet build SWLOR.Game.Server.sln --no-restore` but the environment lacks `dotnet`, so an actual build could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0527807bf883298c104be9e1b06cf2)