### PR TITLE
Gate Smuggler's Moon flights behind SmugglerPass

### DIFF
--- a/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
+using SWLOR.Game.Server.Service.KeyItemService;
 using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.PropertyService;
 
@@ -58,8 +59,10 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private void MainPageInit(DialogPage page)
         {
             var model = GetDataModel<Model>();
+            var player = GetPC();
             var terminal = GetDialogTarget();
             var currentLocation = (PlanetType)GetLocalInt(terminal, "CURRENT_LOCATION");
+            var hasSmugglerPass = KeyItem.HasKeyItem(player, KeyItemType.SmugglerPass);
 
             page.Header = "Charter flights leave hourly. Please select one our available destinations below.";
 
@@ -68,8 +71,8 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
             foreach (var (type, planet) in planets)
             {
                 if (currentLocation == type ||
-                     type == PlanetType.SmugglersMoon ||
-                     type == PlanetType.SmugglersMoonStation)
+                    type == PlanetType.SmugglersMoonStation ||
+                    (type == PlanetType.SmugglersMoon && !hasSmugglerPass))
                 {
                     continue;
                 }


### PR DESCRIPTION
### Motivation
- Allow NPC starport charters to offer Smuggler's Moon only to players who have the `KeyItemType.SmugglerPass`, while keeping Smuggler's Moon Station inaccessible via NPC flights as an intentional ship-only/safeguard destination.

### Description
- Added `KeyItemService` usage and a `hasSmugglerPass` check in `StarportFlightsDialog.MainPageInit` and changed the destination filter so `SmugglersMoon` is shown only when the player has the pass while `SmugglersMoonStation` remains excluded.

### Testing
- Ran `git diff --check` successfully and attempted `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj --no-restore` but the build could not be executed because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e8f757088329a7a5cc0997c54947)