### PR TITLE
Require Smuggler Pass for Smuggler's Moon flights and set Smuggler's Moon fare

### DIFF
--- a/SWLOR.Game.Server/Enumeration/PlanetType.cs
+++ b/SWLOR.Game.Server/Enumeration/PlanetType.cs
@@ -83,7 +83,7 @@ namespace SWLOR.Game.Server.Enumeration
 			"Smuggler's Moon - ",
 			"SmugglersMoon_Orbit",
 			"SMUGGLERS_MOON_LANDING",
-			0,
+			500,
 			true)]
 		SmugglersMoon = 256,
 		[Description("Smuggler's Moon Station")]

--- a/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
+++ b/SWLOR.Game.Server/Feature/DialogDefinition/StarportFlightsDialog.cs
@@ -3,6 +3,7 @@ using SWLOR.Game.Server.Entity;
 using SWLOR.Game.Server.Enumeration;
 using SWLOR.Game.Server.Service;
 using SWLOR.Game.Server.Service.DialogService;
+using SWLOR.Game.Server.Service.KeyItemService;
 using SWLOR.Game.Server.Service.LogService;
 using SWLOR.Game.Server.Service.PropertyService;
 
@@ -58,8 +59,10 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
         private void MainPageInit(DialogPage page)
         {
             var model = GetDataModel<Model>();
+            var player = GetPC();
             var terminal = GetDialogTarget();
             var currentLocation = (PlanetType)GetLocalInt(terminal, "CURRENT_LOCATION");
+            var hasSmugglerPass = KeyItem.HasKeyItem(player, KeyItemType.SmugglerPass);
 
             page.Header = "Charter flights leave hourly. Please select one our available destinations below.";
 
@@ -68,8 +71,8 @@ namespace SWLOR.Game.Server.Feature.DialogDefinition
             foreach (var (type, planet) in planets)
             {
                 if (currentLocation == type ||
-                     type == PlanetType.SmugglersMoon ||
-                     type == PlanetType.SmugglersMoonStation)
+                    type == PlanetType.SmugglersMoonStation ||
+                    (type == PlanetType.SmugglersMoon && !hasSmugglerPass))
                 {
                     continue;
                 }


### PR DESCRIPTION
### Motivation

- Ensure Smuggler's Moon charges an NPC transportation fee and restrict flights there to players who own the Smuggler Pass.
- Prevent Smuggler's Moon Station from being offered as a destination.

### Description

- Set `SmugglersMoon` `NPCTransportationFee` from `0` to `500` in `PlanetType.cs`.
- Import the key item service and check `KeyItem.HasKeyItem(player, KeyItemType.SmugglerPass)` in `StarportFlightsDialog.cs` and skip the `SmugglersMoon` destination when the player does not have the pass.
- Maintain exclusion of `SmugglersMoonStation` from available destinations.

### Testing

- Built the project successfully after changes.
- Ran the automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e8f757088329a7a5cc0997c54947)