### PR TITLE
Add biotechnology component crafting foundation

### DIFF
--- a/Module/uti/bio_antivenom.uti.json
+++ b/Module/uti/bio_antivenom.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 10
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 519
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 10
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A neutral biological base suitable for future First Aid antivenom and treatment recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A neutral biological base suitable for future First Aid antivenom and treatment recipes."
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Antivenom Base"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 154
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_antivenom"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_antivenom"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 154
+  }
+}

--- a/Module/uti/bio_fungalcult.uti.json
+++ b/Module/uti/bio_fungalcult.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 10
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 519
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 10
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A controlled fungal culture prepared for Agriculture and other biological recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A controlled fungal culture prepared for Agriculture and other biological recipes."
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Fungal Culture"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 152
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_fungalcult"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_fungalcult"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 152
+  }
+}

--- a/Module/uti/bio_incubmed.uti.json
+++ b/Module/uti/bio_incubmed.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 10
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 519
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 10
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A nutrient-rich medium prepared for future Beast Mastery incubation recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A nutrient-rich medium prepared for future Beast Mastery incubation recipes."
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Incubation Medium"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 155
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_incubmed"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_incubmed"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 155
+  }
+}

--- a/Module/uti/bio_plantcult.uti.json
+++ b/Module/uti/bio_plantcult.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 10
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 519
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 10
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A stabilized culture of viable plant cells prepared for Agriculture seed, fertilizer, and growing recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A stabilized culture of viable plant cells prepared for Agriculture seed, fertilizer, and growing recipes."
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Plant Culture"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 151
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_plantcult"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_plantcult"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 151
+  }
+}

--- a/Module/uti/bio_proteinext.uti.json
+++ b/Module/uti/bio_proteinext.uti.json
@@ -1,0 +1,85 @@
+{
+  "__data_type": "UTI ",
+  "AddCost": {
+    "type": "dword",
+    "value": 10
+  },
+  "BaseItem": {
+    "type": "int",
+    "value": 519
+  },
+  "Charges": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Cost": {
+    "type": "dword",
+    "value": 10
+  },
+  "Cursed": {
+    "type": "byte",
+    "value": 0
+  },
+  "DescIdentified": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A refined protein concentrate intended as an intermediate material for feed and incubation recipes."
+    }
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A refined protein concentrate intended as an intermediate material for feed and incubation recipes."
+    }
+  },
+  "Identified": {
+    "type": "byte",
+    "value": 1
+  },
+  "LocalizedName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Protein Extract"
+    }
+  },
+  "ModelPart1": {
+    "type": "byte",
+    "value": 153
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 64
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 0
+  },
+  "PropertiesList": {
+    "type": "list",
+    "value": []
+  },
+  "StackSize": {
+    "type": "word",
+    "value": 1
+  },
+  "Stolen": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_proteinext"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_proteinext"
+  },
+  "xModelPart1": {
+    "type": "word",
+    "value": 153
+  }
+}

--- a/Module/utp/bio_lab_station.utp.json
+++ b/Module/utp/bio_lab_station.utp.json
@@ -1,0 +1,239 @@
+{
+  "__data_type": "UTP ",
+  "AnimationState": {
+    "type": "byte",
+    "value": 0
+  },
+  "Appearance": {
+    "type": "dword",
+    "value": 20565
+  },
+  "AutoRemoveKey": {
+    "type": "byte",
+    "value": 0
+  },
+  "BodyBag": {
+    "type": "byte",
+    "value": 0
+  },
+  "CloseLockDC": {
+    "type": "byte",
+    "value": 0
+  },
+  "Comment": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "Conversation": {
+    "type": "resref",
+    "value": ""
+  },
+  "CurrentHP": {
+    "type": "short",
+    "value": 10
+  },
+  "Description": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "A sealed workstation used to process biological samples into intermediate crafting components."
+    }
+  },
+  "DisarmDC": {
+    "type": "byte",
+    "value": 0
+  },
+  "Faction": {
+    "type": "dword",
+    "value": 1
+  },
+  "Fort": {
+    "type": "byte",
+    "value": 5
+  },
+  "Hardness": {
+    "type": "byte",
+    "value": 5
+  },
+  "HasInventory": {
+    "type": "byte",
+    "value": 0
+  },
+  "HP": {
+    "type": "short",
+    "value": 10
+  },
+  "Interruptable": {
+    "type": "byte",
+    "value": 1
+  },
+  "KeyName": {
+    "type": "cexostring",
+    "value": ""
+  },
+  "KeyRequired": {
+    "type": "byte",
+    "value": 0
+  },
+  "Lockable": {
+    "type": "byte",
+    "value": 0
+  },
+  "Locked": {
+    "type": "byte",
+    "value": 0
+  },
+  "LocName": {
+    "type": "cexolocstring",
+    "value": {
+      "0": "Biotechnology Lab Station"
+    }
+  },
+  "OnClick": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnClosed": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnDamaged": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnDeath": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnDisarm": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnHeartbeat": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnInvDisturbed": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnLock": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnMeleeAttacked": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnOpen": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnSpellCastAt": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnTrapTriggered": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnUnlock": {
+    "type": "resref",
+    "value": ""
+  },
+  "OnUsed": {
+    "type": "resref",
+    "value": "craft_on_used"
+  },
+  "OnUserDefined": {
+    "type": "resref",
+    "value": ""
+  },
+  "OpenLockDC": {
+    "type": "byte",
+    "value": 0
+  },
+  "PaletteID": {
+    "type": "byte",
+    "value": 3
+  },
+  "Plot": {
+    "type": "byte",
+    "value": 1
+  },
+  "PortraitId": {
+    "type": "word",
+    "value": 0
+  },
+  "Ref": {
+    "type": "byte",
+    "value": 0
+  },
+  "Static": {
+    "type": "byte",
+    "value": 0
+  },
+  "Tag": {
+    "type": "cexostring",
+    "value": "bio_lab_station"
+  },
+  "TemplateResRef": {
+    "type": "resref",
+    "value": "bio_lab_station"
+  },
+  "TrapDetectable": {
+    "type": "byte",
+    "value": 1
+  },
+  "TrapDetectDC": {
+    "type": "byte",
+    "value": 0
+  },
+  "TrapDisarmable": {
+    "type": "byte",
+    "value": 1
+  },
+  "TrapFlag": {
+    "type": "byte",
+    "value": 0
+  },
+  "TrapOneShot": {
+    "type": "byte",
+    "value": 1
+  },
+  "TrapType": {
+    "type": "byte",
+    "value": 0
+  },
+  "Type": {
+    "type": "byte",
+    "value": 0
+  },
+  "Useable": {
+    "type": "byte",
+    "value": 1
+  },
+  "VarTable": {
+    "type": "list",
+    "value": [
+      {
+        "__struct_id": 0,
+        "Name": {
+          "type": "cexostring",
+          "value": "CRAFTING_SKILL_TYPE_ID"
+        },
+        "Type": {
+          "type": "dword",
+          "value": 1
+        },
+        "Value": {
+          "type": "int",
+          "value": 36
+        }
+      }
+    ]
+  },
+  "Will": {
+    "type": "byte",
+    "value": 0
+  }
+}

--- a/SWLOR.Game.Server/Feature/PerkDefinition/BiotechnologyPerkDefinition.cs
+++ b/SWLOR.Game.Server/Feature/PerkDefinition/BiotechnologyPerkDefinition.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using SWLOR.Game.Server.Service.PerkService;
+using SWLOR.Game.Server.Service.SkillService;
+
+namespace SWLOR.Game.Server.Feature.PerkDefinition
+{
+    public class BiotechnologyPerkDefinition : IPerkListDefinition
+    {
+        private readonly PerkBuilder _builder = new();
+
+        public Dictionary<PerkType, PerkDetail> BuildPerks()
+        {
+            BiologicalAnalysis();
+            LaboratoryTechniques();
+            SamplePreservation();
+            AdvancedBiologicalProcessing();
+            ResearchProjects();
+
+            return _builder.Build();
+        }
+
+        private void BiologicalAnalysis()
+        {
+            _builder.Create(PerkCategoryType.Biotechnology, PerkType.BiologicalAnalysis)
+                .Name("Biological Analysis")
+                .AddPerkLevel().Description("Grants access to tier 1 biological processing recipes.").Price(1)
+                .AddPerkLevel().Description("Grants access to tier 2 biological processing recipes.").Price(1).RequirementSkill(SkillType.Biotechnology, 10)
+                .AddPerkLevel().Description("Grants access to tier 3 biological processing recipes.").Price(2).RequirementSkill(SkillType.Biotechnology, 20)
+                .AddPerkLevel().Description("Grants access to tier 4 biological processing recipes.").Price(3).RequirementSkill(SkillType.Biotechnology, 30)
+                .AddPerkLevel().Description("Grants access to tier 5 biological processing recipes.").Price(3).RequirementSkill(SkillType.Biotechnology, 40);
+        }
+
+        private void LaboratoryTechniques()
+        {
+            _builder.Create(PerkCategoryType.Biotechnology, PerkType.LaboratoryTechniques)
+                .Name("Laboratory Techniques")
+                .AddPerkLevel().Description("Improves biological processing efficiency through better lab handling.").Price(1).RequirementSkill(SkillType.Biotechnology, 5)
+                .AddPerkLevel().Description("Further improves biological processing efficiency through precise lab technique.").Price(2).RequirementSkill(SkillType.Biotechnology, 25);
+        }
+
+        private void SamplePreservation()
+        {
+            _builder.Create(PerkCategoryType.Biotechnology, PerkType.SamplePreservation)
+                .Name("Sample Preservation")
+                .AddPerkLevel().Description("Gives a small chance to preserve a biological sample during processing.").Price(1).RequirementSkill(SkillType.Biotechnology, 8)
+                .AddPerkLevel().Description("Increases the chance to preserve a biological sample during processing.").Price(2).RequirementSkill(SkillType.Biotechnology, 28);
+        }
+
+        private void AdvancedBiologicalProcessing()
+        {
+            _builder.Create(PerkCategoryType.Biotechnology, PerkType.AdvancedBiologicalProcessing)
+                .Name("Advanced Biological Processing")
+                .AddPerkLevel().Description("Unlocks advanced biological component processing.").Price(2).RequirementSkill(SkillType.Biotechnology, 20)
+                .AddPerkLevel().Description("Unlocks expert biological component processing.").Price(3).RequirementSkill(SkillType.Biotechnology, 40);
+        }
+
+        private void ResearchProjects()
+        {
+            _builder.Create(PerkCategoryType.Biotechnology, PerkType.BiotechnologyResearchProjects)
+                .Name("Research Projects")
+                .AddPerkLevel().Description("Allows one additional Biotechnology processing or research project to be managed.").Price(2).RequirementSkill(SkillType.Biotechnology, 15)
+                .AddPerkLevel().Description("Allows two additional Biotechnology processing or research projects to be managed.").Price(3).RequirementSkill(SkillType.Biotechnology, 35);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Feature/RecipeDefinition/BiotechnologyRecipeDefinition/BiologicalComponentRecipes.cs
+++ b/SWLOR.Game.Server/Feature/RecipeDefinition/BiotechnologyRecipeDefinition/BiologicalComponentRecipes.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using SWLOR.Game.Server.Service.CraftService;
+using SWLOR.Game.Server.Service.PerkService;
+using SWLOR.Game.Server.Service.SkillService;
+
+namespace SWLOR.Game.Server.Feature.RecipeDefinition.BiotechnologyRecipeDefinition
+{
+    public class BiologicalComponentRecipes : IRecipeListDefinition
+    {
+        private readonly RecipeBuilder _builder = new();
+
+        public Dictionary<RecipeType, RecipeDetail> BuildRecipes()
+        {
+            Components();
+            return _builder.Build();
+        }
+
+        private void Components()
+        {
+            _builder.Create(RecipeType.PlantCulture, SkillType.Biotechnology)
+                .Category(RecipeCategoryType.BiologicalComponent).Resref("bio_plantcult").Level(5).Quantity(1)
+                .RequirementPerk(PerkType.BiologicalAnalysis, 1)
+                .Component("herb_m", 2).Component("night_flowerlily", 1);
+
+            _builder.Create(RecipeType.FungalCulture, SkillType.Biotechnology)
+                .Category(RecipeCategoryType.BiologicalComponent).Resref("bio_fungalcult").Level(8).Quantity(1)
+                .RequirementPerk(PerkType.BiologicalAnalysis, 1)
+                .Component("mushroom", 3).Component("herb_question", 1);
+
+            _builder.Create(RecipeType.ProteinExtract, SkillType.Biotechnology)
+                .Category(RecipeCategoryType.BiologicalComponent).Resref("bio_proteinext").Level(12).Quantity(1)
+                .RequirementPerk(PerkType.BiologicalAnalysis, 2)
+                .Component("wild_meat", 2).Component("mynock_meat", 1);
+
+            _builder.Create(RecipeType.AntivenomBase, SkillType.Biotechnology)
+                .Category(RecipeCategoryType.BiologicalComponent).Resref("bio_antivenom").Level(18).Quantity(1)
+                .RequirementPerk(PerkType.BiologicalAnalysis, 2)
+                .Component("mserp_meat", 1).Component("herb_digested", 2);
+
+            _builder.Create(RecipeType.IncubationMedium, SkillType.Biotechnology)
+                .Category(RecipeCategoryType.BiologicalComponent).Resref("bio_incubmed").Level(25).Quantity(1)
+                .RequirementPerk(PerkType.AdvancedBiologicalProcessing, 1)
+                .Component("bio_proteinext", 1).Component("bio_plantcult", 1).Component("hydrolase_orange", 1);
+        }
+    }
+}

--- a/SWLOR.Game.Server/Service/CraftService/RecipeCategoryType.cs
+++ b/SWLOR.Game.Server/Service/CraftService/RecipeCategoryType.cs
@@ -132,6 +132,8 @@ namespace SWLOR.Game.Server.Service.CraftService
         StarshipAmmo = 61,
         [RecipeCategory("Capital Module Recipes", true)]
         CapitalShipModule = 62,
+        [RecipeCategory("Biological Component", true)]
+        BiologicalComponent = 63,
     }
 
     public class RecipeCategoryAttribute : Attribute

--- a/SWLOR.Game.Server/Service/CraftService/RecipeType.cs
+++ b/SWLOR.Game.Server/Service/CraftService/RecipeType.cs
@@ -807,6 +807,12 @@
         LargeHouseStyle4 = 1516,
         LabStyle1 = 1517,
 
+        PlantCulture = 4799,
+        FungalCulture = 4800,
+        ProteinExtract = 4801,
+        AntivenomBase = 4802,
+        IncubationMedium = 4803,
+
         #endregion
 
         #region Cooking: 2001-3000
@@ -1029,6 +1035,12 @@
         KeebadasBinggona = 2210,
         SandoGDizzards = 2211,
         CartelCakes = 2212,
+
+        PlantCulture = 4799,
+        FungalCulture = 4800,
+        ProteinExtract = 4801,
+        AntivenomBase = 4802,
+        IncubationMedium = 4803,
 
         #endregion
 
@@ -2590,6 +2602,12 @@
         CapitalPowerDiverter = 4797,
         CorvetteCrusader = 4798,
 
+
+        PlantCulture = 4799,
+        FungalCulture = 4800,
+        ProteinExtract = 4801,
+        AntivenomBase = 4802,
+        IncubationMedium = 4803,
 
         #endregion
 

--- a/SWLOR.Game.Server/Service/PerkService/PerkCategoryType.cs
+++ b/SWLOR.Game.Server/Service/PerkService/PerkCategoryType.cs
@@ -138,6 +138,9 @@ namespace SWLOR.Game.Server.Service.PerkService
 
         [PerkCategory("Beast - Force", true)]
         BeastForce = 44,
+
+        [PerkCategory("Biotechnology", true)]
+        Biotechnology = 45,
     }
 
     public class PerkCategoryAttribute : Attribute

--- a/SWLOR.Game.Server/Service/PerkService/PerkType.cs
+++ b/SWLOR.Game.Server/Service/PerkService/PerkType.cs
@@ -305,5 +305,10 @@
         AdrenalStim = 298,
         ResearchProjects = 299,
         PommelStrike = 300,
+        BiologicalAnalysis = 301,
+        LaboratoryTechniques = 302,
+        SamplePreservation = 303,
+        AdvancedBiologicalProcessing = 304,
+        BiotechnologyResearchProjects = 305,
     }
 }

--- a/SWLOR.Game.Server/Service/SkillService/SkillType.cs
+++ b/SWLOR.Game.Server/Service/SkillService/SkillType.cs
@@ -373,6 +373,16 @@ namespace SWLOR.Game.Server.Service.SkillService
            false,
            false)]
            Ewokese = 35,
+
+        [Skill(SkillCategoryType.Crafting,
+            "Biotechnology",
+            50,
+            true,
+            "Ability to process biological materials into specialized crafting components.",
+            true,
+            true,
+            false)]
+        Biotechnology = 36,
     }
 
     public class SkillAttribute : Attribute


### PR DESCRIPTION
### Motivation

- Provide a dedicated Biotechnology crafting skill focused on processing biological materials into reusable intermediate components. 
- Enable downstream professions (Agriculture, Beast Mastery, First Aid, Engineering/Fabrication) to consume biological components without duplicating existing systems like Fabrication or First Aid. 
- Establish initial progression and perks so Biotechnology can be expanded later with recipes and laboratory equipment.

### Description

- Adds a new skill `SkillType.Biotechnology` in `SWLOR.Game.Server/Service/SkillService/SkillType.cs` to represent the Biotechnology crafting skill. 
- Introduces a `BiologicalComponent` recipe category in `SWLOR.Game.Server/Service/CraftService/RecipeCategoryType.cs` and new recipe IDs for `PlantCulture`, `FungalCulture`, `ProteinExtract`, `AntivenomBase`, and `IncubationMedium` in `SWLOR.Game.Server/Service/CraftService/RecipeType.cs`. 
- Adds a new perk category `PerkCategoryType.Biotechnology` and new perk IDs in `SWLOR.Game.Server/Service/PerkService/*` and implements perk progression in `SWLOR.Game.Server/Feature/PerkDefinition/BiotechnologyPerkDefinition.cs` with `BiologicalAnalysis`, `LaboratoryTechniques`, `SamplePreservation`, `AdvancedBiologicalProcessing`, and `BiotechnologyResearchProjects`. 
- Implements initial Biotechnology recipes in `SWLOR.Game.Server/Feature/RecipeDefinition/BiotechnologyRecipeDefinition/BiologicalComponentRecipes.cs` and creates UTI item blueprints for the five intermediate components at `Module/uti/bio_*.uti.json`.

### Testing

- Ran `git diff --check` which reported no index/trailing-whitespace errors. 
- Ran `git status --short` to verify changed and new files are present. 
- Attempted `dotnet build SWLOR.Game.Server/SWLOR.Game.Server.csproj --no-restore` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c28a85104832980ba03cc5fb2e788)